### PR TITLE
Updating the changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,14 +4,6 @@
 
 ## Changes in 1.4.2 : ##
 
-- Functionally same as 1.4.1. Fixing the error in the included wheel of the project.
-
-## Changes in 1.4.1 : ##
-
-- Same as 1.4.0. Had to bump the version in order to include the wheel for the project.
-
-## Changes in 1.4.0 : ##
-
 - Implement Upsert. New UpsertXXX methods added to support Upsert feature.
 - Implement ID Based Routing. No public API changes, all changes internal.
 


### PR DESCRIPTION
Updating the changelog to remove references to 1.4.0 and 1.4.1 as they
were momentarily created and were removed from pypi website. 1.4.2 is
the correct version.