### PR TITLE
small testing related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Idea IDE
+.idea/*

--- a/README.md
+++ b/README.md
@@ -23,13 +23,23 @@ Welcome to DocumentDB.
     $ pip install pydocumentdb
 
 
-2) To run tests:
+2) Testing:
+
+Some of the test files such as [crud_tests.py](https://github.com/Azure/azure-documentdb-python/blob/fe95945cae62ee4a68ae53bc5519bec11f07522c/test/crud_tests.py) require you to enter your Azure DocumentDB master key and host endpoint in that file: 
+    
+    masterKey = '[YOUR_KEY_HERE]'
+    host = '[YOUR_ENDPOINT_HERE]'
+
+To run the tests:
 
     $ python test/crud_tests.py
 
     If you use Microsoft Visual Studio, open the project file python.pyproj,
     and press F5.
 
+**Note:**  
+Test cases in [crud_tests.py](https://github.com/Azure/azure-documentdb-python/blob/fe95945cae62ee4a68ae53bc5519bec11f07522c/test/crud_tests.py) create collections in your DocumentDB account. Collections are billing entities. By running these test cases, you may incur monetary costs on your account.
+  
 
 3) To generate documentations:
 

--- a/pydocumentdb/auth.py
+++ b/pydocumentdb/auth.py
@@ -2,9 +2,9 @@
 
 """Authorization helper functions.
 """
-
-from hashlib import sha256
+import base64
 import hmac
+from hashlib import sha256
 
 import pydocumentdb.http_constants as http_constants
 
@@ -58,7 +58,9 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         dict
 
     """
-    key = master_key.decode('base64')
+    # The master_key from Azure UI which the dev/user specifies is base64
+    # encoded.
+    key = base64.b64decode(master_key)
 
     # Skipping lower casing of resource_id_or_fullname since it may now contain "ID" of the resource as part of the fullname
     text = '{verb}\n{resource_type}\n{resource_id_or_fullname}\n{x_date}\n{http_date}\n'.format(
@@ -67,11 +69,25 @@ def __GetAuthorizationTokenUsingMasterKey(verb,
         resource_id_or_fullname=(resource_id_or_fullname or ''),
         x_date=headers.get(http_constants.HttpHeaders.XDate, '').lower(),
         http_date=headers.get(http_constants.HttpHeaders.HttpDate, '').lower())
-   
-    body = text.decode('utf8')
+
+    try:
+        # Python2.7 - decode from bytestring to unicode utf-8 string
+        body = text.decode('utf8')
+    except AttributeError:
+        # Python3 convert string to bytes array with utf-8 encoding
+        body = text.encode('utf-8')
 
     hm = hmac.new(key, body, sha256)
-    signature = hm.digest().encode('base64')
+    digest = hm.digest()
+    # Encode the digest for the signature
+    try:
+        # Python3 uses encodebytes, encodestring is deprecated.
+        # encodebytes returns bytes so decode to utf-8 string
+        signature = base64.encodebytes(digest).decode('utf-8')
+    except AttributeError:
+        # Python2.7 uses encodestring
+        # returns string
+        signature = base64.encodestring(digest)
 
     master_token = 'master'
     token_version = '1.0'

--- a/pydocumentdb/backoff_retry_utility.py
+++ b/pydocumentdb/backoff_retry_utility.py
@@ -22,7 +22,7 @@ def Execute(callback_fn, resource_throttle_retry_policy):
         try:
             callback_fn()
             break  # Break from the while loop if no exception happened.
-        except Exception, e:
+        except Exception as e:
             should_retry = resource_throttle_retry_policy.ShouldRetry(e)
             if not should_retry:
                 raise

--- a/pydocumentdb/consistent_hash_ring.py
+++ b/pydocumentdb/consistent_hash_ring.py
@@ -20,7 +20,16 @@
 #SOFTWARE.
 
 import pydocumentdb.partition as partition
+
 from struct import *
+
+
+try:
+    basestring
+except NameError:
+    # Python3 doesn't have basestring
+    basestring = (str, bytes)
+
 
 class _ConsistentHashRing(object):
     """The ConsistentHashRing class implements a consistent hash ring using the 

--- a/pydocumentdb/https_connection.py
+++ b/pydocumentdb/https_connection.py
@@ -6,11 +6,11 @@
 
 import socket
 import ssl
-
+import sys
 
 try:
     from httplib import HTTPConnection, HTTPS_PORT
-except:
+except ImportError:
     from http.client import HTTPConnection, HTTPS_PORT
 
 
@@ -30,7 +30,13 @@ class HTTPSConnection(HTTPConnection):
             - `timeout`: int, the connection timeout in milliseconds.
             - `source_address`: str, the source address.
         """
-        HTTPConnection.__init__(self, host, port, strict, timeout, source_address)
+        if sys.version_info > (3,):
+            # Python3 doesn't expect the strict parameter.
+            HTTPConnection.__init__(self, host, port, timeout, source_address)
+        else:
+            HTTPConnection.__init__(self, host, port, strict,
+                                    timeout, source_address)
+
         self._ssl_configuration = ssl_configuration
 
     def connect(self):

--- a/pydocumentdb/murmur_hash.py
+++ b/pydocumentdb/murmur_hash.py
@@ -21,6 +21,13 @@
 
 from struct import *
 
+
+try:
+    xrange
+except NameError:
+    # In Python3 range is xrange
+    xrange = range
+
 '''
 pymmh3 was written by Fredrik Kihlander, and is placed in the public
 domain. The author hereby disclaims copyright to this source code.

--- a/pydocumentdb/partition.py
+++ b/pydocumentdb/partition.py
@@ -38,7 +38,19 @@ class _Partition(object):
         if self == other:
             return 0
         return self.CompareTo(other.hash_value)
-    
+
+    def __lt__(self, other):
+        val = self.__cmp__(other)
+        # CompareTo (and therefore __cmp__) return a negative value for less
+        # than, and positive for greater than. __lt__ must return a boolean
+        # meaning 'is self less than other'.
+        # First change -1 to 0 which is False (-1 is True), then
+        # return the opposite of the return value from __cmp__ to align with
+        # expected response from __lt__.
+        if val == -1:
+            val = 0
+        return not bool(val)
+
     def CompareTo(self, other_hash_value):
         """Compares the passed hash value with the hash value of this object
         """

--- a/pydocumentdb/synchronized_request.py
+++ b/pydocumentdb/synchronized_request.py
@@ -4,8 +4,11 @@
 """
 
 import json
-import urlparse
-import urllib
+import sys
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 import pydocumentdb.documents as documents
 import pydocumentdb.errors as errors
@@ -30,9 +33,15 @@ try:
 except NameError:
     basestring = (str, bytes)
 
+try:
+    unicode
+except NameError:
+    # Python3 doesn't have unicode as a keyword
+    unicode = None
+
 
 def _RequestBodyFromData(data):
-    """Gets requestion body from data.
+    """Gets request body from data.
 
     When `data` is dict and list into unicode string; otherwise return `data`
     without making any change.
@@ -44,11 +53,14 @@ def _RequestBodyFromData(data):
         str, unicode, file-like stream object, or None
 
     """
+    jsonstr = None
     if isinstance(data, basestring) or _IsReadableStream(data):
         return data
     elif isinstance(data, (dict, list, tuple)):
-        return json.dumps(data, separators=(',',':')).decode('utf8')
-    return None
+        jsonstr = json.dumps(data, separators=(',', ':'))
+        if isinstance(jsonstr, bytes):
+            jsonstr = jsonstr.decode('utf8')
+    return jsonstr
 
 
 def _InternalRequest(connection_policy, request_options, request_body):
@@ -95,6 +107,7 @@ def _InternalRequest(connection_policy, request_options, request_body):
         return (response, headers)
 
     data = response.read()
+    connection.close()
     if response.status >= 400:
         raise errors.HTTPFailure(response.status, data, headers)
 
@@ -103,10 +116,10 @@ def _InternalRequest(connection_policy, request_options, request_body):
         result = data
     else:
         if len(data) > 0:
-            try:
-                result = json.loads(data)
-            except:
-                raise errors.JSONParseFailure(data)
+            # In Python3 data is utf8 encoded bytes, decode to string for json
+            if sys.version_info > (3,):
+                data = data.decode('utf-8')
+            result = json.loads(data)
 
     return (result, headers)
 
@@ -139,9 +152,9 @@ def SynchronizedRequest(connection_policy,
     if request_data:
         request_body = _RequestBodyFromData(request_data)
         if not request_body:
-           raise errors.UnexpectedDataType(
-               'parameter data must be a JSON object, string or' +
-               ' readable stream.')
+            raise errors.UnexpectedDataType(
+                'parameter data must be a JSON object, string or' +
+                ' readable stream.')
 
     request_options = {}
     parse_result = urlparse.urlparse(base_url)
@@ -150,13 +163,14 @@ def SynchronizedRequest(connection_policy,
     request_options['path'] = path
     request_options['method'] = method
     if query_params:
-        request_options['path'] += '?' + urllib.urlencode(query_params)
+        request_options['path'] += '?' + urlparse.urlencode(query_params)
 
     request_options['headers'] = headers
-    if request_body and (type(request_body) is str or
-                         type(request_body) is unicode):
+    if (request_body and
+            (type(request_body) in [str, bytes] or
+             (unicode is not None and type(request_body) is unicode))):
         request_options['headers'][http_constants.HttpHeaders.ContentLength] = (
             len(request_body))
-    elif request_body == None:
+    elif request_body is None:
         request_options['headers'][http_constants.HttpHeaders.ContentLength] = 0
     return _InternalRequest(connection_policy, request_options, request_body)

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -25,6 +25,8 @@ from __builtin__ import *
 
 TEST_DB_NAME = 'sample database'
 
+masterKey = '[YOUR_KEY_HERE]'
+host = '[YOUR_ENDPOINT_HERE]'
 
 if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
     raise Exception(

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -3,25 +3,34 @@
 """End to end test.
 """
 
-import logging
-import unittest
 import json
 import os.path
+import unittest
+import sys
 
-import pydocumentdb.documents as documents
-import pydocumentdb.document_client as document_client
-import pydocumentdb.errors as errors
-import pydocumentdb.http_constants as http_constants
-import pydocumentdb.hash_partition_resolver as hash_partition_resolver
-import pydocumentdb.range_partition_resolver as range_partition_resolver
-import pydocumentdb.murmur_hash as murmur_hash
-import pydocumentdb.consistent_hash_ring as consistent_hash_ring
-import pydocumentdb.range as partition_range
-import test_partition_resolver as test_partition_resolver
-import pydocumentdb.base as base
+try:
+    # Python2.7
+    from __builtin__ import *
+except ImportError:
+    # Python3
+    import builtins
 
 from struct import *
-from __builtin__ import *
+import pydocumentdb.base as base
+import pydocumentdb.consistent_hash_ring as consistent_hash_ring
+import pydocumentdb.document_client as document_client
+import pydocumentdb.documents as documents
+import pydocumentdb.errors as errors
+import pydocumentdb.hash_partition_resolver as hash_partition_resolver
+import pydocumentdb.http_constants as http_constants
+import pydocumentdb.murmur_hash as murmur_hash
+import pydocumentdb.range as partition_range
+import pydocumentdb.range_partition_resolver as range_partition_resolver
+import test.test_partition_resolver as test_partition_resolver
+
+# If Python3, set long to int
+if sys.version_info > (3,):
+    long = int
 
 TEST_DB_NAME = 'sample database'
 
@@ -33,7 +42,6 @@ if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
         "You must specify your Azure DocumentDB account values for "
         "'masterKey' and 'host' at the top of this file to run the tests.")
 
-
 #IMPORTANT NOTES:
   
 #  	Most test cases in this file create collections in your DocumentDB account.
@@ -41,6 +49,48 @@ if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
   
 #  	To Run the test, replace the two member fields (masterKey and host) with values 
 #   associated with your DocumentDB account.
+
+
+class ReadableStream(object):
+    """Customized file-like stream.
+    """
+
+    def __init__(self, chunks=None):
+        """Initialization.
+
+        :Parameters:
+            - `chunks`: list
+
+        """
+        if chunks is None:
+            chunks = ['first chunk ', 'second chunk']
+
+        if sys.version_info > (3,):
+            # Python3 httpclient ssl connection expects bytes data
+            chunks = [c.encode('utf-8') for c in chunks]
+
+        self._chunks = chunks
+
+    def read(self, n=-1):
+        """Simulates the read method in a file stream.
+
+        :Parameters:
+            - `n`: int
+
+        :Returns:
+            str
+
+        """
+        if self._chunks:
+            return self._chunks.pop(0)
+        else:
+            return ''
+
+    def __len__(self):
+        """To make len(ReadableStream) work.
+        """
+        return sum([len(chunk) for chunk in self._chunks])
+
 
 class CRUDTests(unittest.TestCase):
     """Python CRUD Tests.
@@ -642,38 +692,7 @@ class CRUDTests(unittest.TestCase):
         client.DeleteCollection(self.GetDocumentCollectionLink(created_db, created_collection))
 
     def test_partitioned_collection_attachment_crud_and_query(self):
-        class ReadableStream(object):
-            """Customized file-like stream.
-            """
 
-            def __init__(self, chunks = ['first chunk ', 'second chunk']):
-                """Initialization.
-
-                :Parameters:
-                    - `chunks`: list
-
-                """
-                self._chunks = list(chunks)
-
-            def read(self, n=-1):
-                """Simulates the read method in a file stream.
-
-                :Parameters:
-                    - `n`: int
-
-                :Returns:
-                    str
-
-                """
-                if self._chunks:
-                    return self._chunks.pop(0)
-                else:
-                    return ''
-
-            def __len__(self):
-                """To make len(ReadableStream) work.
-                """
-                return sum([len(chunk) for chunk in self._chunks])
 
 
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
@@ -1399,16 +1418,16 @@ class CRUDTests(unittest.TestCase):
             collection_link = self.GetDocumentCollectionLink(created_db, collection, True)
             collection_links.append(collection_link)
 
-        expected_partition_list.append(('dbs/db/colls/coll0', 1076200484L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 1302652881L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 2210251988L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 2341558382L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 2348251587L))
-        expected_partition_list.append(('dbs/db/colls/coll0', 2887945459L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 2894403633L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 3031617259L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 3090861424L))
-        expected_partition_list.append(('dbs/db/colls/coll1', 4222475028L))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(1076200484)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(1302652881)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(2210251988)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(2341558382)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(2348251587)))
+        expected_partition_list.append(('dbs/db/colls/coll0', long(2887945459)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(2894403633)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(3031617259)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(3090861424)))
+        expected_partition_list.append(('dbs/db/colls/coll1', long(4222475028)))
 
         id_partition_key_extractor = lambda document: document['id']
         
@@ -1447,29 +1466,29 @@ class CRUDTests(unittest.TestCase):
         bytes = bytearray(str, encoding='utf-8')
 
         hash_value = murmur_hash._MurmurHash._ComputeHash(bytes)
-        self.assertEqual(1099701186L, hash_value)
+        self.assertEqual(long(1099701186), hash_value)
 
         num = 374.0
         bytes = bytearray(pack('d', num))
 
         hash_value = murmur_hash._MurmurHash._ComputeHash(bytes)
-        self.assertEqual(3717946798L, hash_value)
+        self.assertEqual(long(3717946798), hash_value)
 
-        self._validate_bytes("", 0x1B873593, bytearray(b'\xEE\xA8\xA2\x67'), 1738713326L);
-        self._validate_bytes("1", 0xE82562E4, bytearray(b'\xD0\x92\x24\xED'), 3978597072L);
-        self._validate_bytes("00", 0xB4C39035, bytearray(b'\xFA\x09\x64\x1B'), 459540986L);
-        self._validate_bytes("eyetooth", 0x8161BD86, bytearray(b'\x98\x62\x1C\x6F'), 1864131224L);
-        self._validate_bytes("acid", 0x4DFFEAD7, bytearray(b'\x36\x92\xC0\xB9'), 3116405302L);
-        self._validate_bytes("elevation", 0x1A9E1828, bytearray(b'\xA9\xB6\x40\xDF'), 3745560233L);
-        self._validate_bytes("dent", 0xE73C4579, bytearray(b'\xD4\x59\xE1\xD3'), 3554761172L);
-        self._validate_bytes("homeland", 0xB3DA72CA, bytearray(b'\x06\x4D\x72\xBB'), 3144830214L);
-        self._validate_bytes("glamor", 0x8078A01B, bytearray(b'\x89\x89\xA2\xA7'), 2812447113L);
-        self._validate_bytes("flags", 0x4D16CD6C, bytearray(b'\x52\x87\x66\x02'), 40273746L);
-        self._validate_bytes("democracy", 0x19B4FABD, bytearray(b'\xE4\x55\xD6\xB0'), 2966836708L);
-        self._validate_bytes("bumble", 0xE653280E, bytearray(b'\xFE\xD7\xC3\x0C'), 214161406L);
-        self._validate_bytes("catch", 0xB2F1555F, bytearray(b'\x98\x4B\xB6\xCD'), 3451276184L);
-        self._validate_bytes("omnomnomnivore", 0x7F8F82B0, bytearray(b'\x38\xC4\xCD\xFF'), 4291675192L);
-        self._validate_bytes("The quick brown fox jumps over the lazy dog", 0x4C2DB001, bytearray(b'\x6D\xAB\x8D\xC9'), 3381504877L)
+        self._validate_bytes("", 0x1B873593, bytearray(b'\xEE\xA8\xA2\x67'), long(1738713326))
+        self._validate_bytes("1", 0xE82562E4, bytearray(b'\xD0\x92\x24\xED'), long(3978597072))
+        self._validate_bytes("00", 0xB4C39035, bytearray(b'\xFA\x09\x64\x1B'), long(459540986))
+        self._validate_bytes("eyetooth", 0x8161BD86, bytearray(b'\x98\x62\x1C\x6F'), long(1864131224))
+        self._validate_bytes("acid", 0x4DFFEAD7, bytearray(b'\x36\x92\xC0\xB9'), long(3116405302))
+        self._validate_bytes("elevation", 0x1A9E1828, bytearray(b'\xA9\xB6\x40\xDF'), long(3745560233))
+        self._validate_bytes("dent", 0xE73C4579, bytearray(b'\xD4\x59\xE1\xD3'), long(3554761172))
+        self._validate_bytes("homeland", 0xB3DA72CA, bytearray(b'\x06\x4D\x72\xBB'), long(3144830214))
+        self._validate_bytes("glamor", 0x8078A01B, bytearray(b'\x89\x89\xA2\xA7'), long(2812447113))
+        self._validate_bytes("flags", 0x4D16CD6C, bytearray(b'\x52\x87\x66\x02'), long(40273746))
+        self._validate_bytes("democracy", 0x19B4FABD, bytearray(b'\xE4\x55\xD6\xB0'), long(2966836708))
+        self._validate_bytes("bumble", 0xE653280E, bytearray(b'\xFE\xD7\xC3\x0C'), long(214161406))
+        self._validate_bytes("catch", 0xB2F1555F, bytearray(b'\x98\x4B\xB6\xCD'), long(3451276184))
+        self._validate_bytes("omnomnomnivore", 0x7F8F82B0, bytearray(b'\x38\xC4\xCD\xFF'), long(4291675192))
+        self._validate_bytes("The quick brown fox jumps over the lazy dog", 0x4C2DB001, bytearray(b'\x6D\xAB\x8D\xC9'), long(3381504877))
 
     def _validate_bytes(self, str, seed, expected_hash_bytes, expected_value):
         hash_value = murmur_hash._MurmurHash._ComputeHash(bytearray(str, encoding='utf-8'), seed)
@@ -1727,40 +1746,6 @@ class CRUDTests(unittest.TestCase):
         self._test_attachment_crud(True);
         
     def _test_attachment_crud(self, is_name_based):
-        class ReadableStream(object):
-            """Customized file-like stream.
-            """
-
-            def __init__(self, chunks = ['first chunk ', 'second chunk']):
-                """Initialization.
-
-                :Parameters:
-                    - `chunks`: list
-
-                """
-                self._chunks = list(chunks)
-
-            def read(self, n=-1):
-                """Simulates the read method in a file stream.
-
-                :Parameters:
-                    - `n`: int
-
-                :Returns:
-                    str
-
-                """
-                if self._chunks:
-                    return self._chunks.pop(0)
-                else:
-                    return ''
-
-            def __len__(self):
-                """To make len(ReadableStream) work.
-                """
-                return sum([len(chunk) for chunk in self._chunks])
-
-
         # Should do attachment CRUD operations successfully
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
@@ -1842,7 +1827,7 @@ class CRUDTests(unittest.TestCase):
         # read attachment media
         media_response = client.ReadMedia(valid_attachment['media'])
         self.assertEqual(media_response,
-                         'first chunk second chunk')
+                         b'first chunk second chunk')
         content_stream = ReadableStream(['modified first chunk ',
                                          'modified second chunk'])
         # update attachment media
@@ -1853,13 +1838,13 @@ class CRUDTests(unittest.TestCase):
         # read media buffered
         media_response = client.ReadMedia(valid_attachment['media'])
         self.assertEqual(media_response,
-                         'modified first chunk modified second chunk')
+                         b'modified first chunk modified second chunk')
         # read media streamed
         client.connection_policy.MediaReadMode = (
             documents.MediaReadMode.Streamed)
         media_response = client.ReadMedia(valid_attachment['media'])
         self.assertEqual(media_response.read(),
-                         'modified first chunk modified second chunk')
+                         b'modified first chunk modified second chunk')
         # share attachment with a second document
         document = client.CreateDocument(self.GetDocumentCollectionLink(db, collection, is_name_based),
                                          {'id': 'document 2'})
@@ -1886,46 +1871,13 @@ class CRUDTests(unittest.TestCase):
 
     # Upsert test for Attachment resource - selflink version
     def test_attachment_upsert_self_link(self):
-        self._test_attachment_upsert(False);
+        self._test_attachment_upsert(False)
 
     # Upsert test for Attachment resource - name based routing version
     def test_attachment_upsert_name_based(self):
-        self._test_attachment_upsert(True);
+        self._test_attachment_upsert(True)
         
     def _test_attachment_upsert(self, is_name_based):
-        class ReadableStream(object):
-            """Customized file-like stream.
-            """
-
-            def __init__(self, chunks = ['first chunk ', 'second chunk']):
-                """Initialization.
-
-                :Parameters:
-                    - `chunks`: list
-
-                """
-                self._chunks = list(chunks)
-
-            def read(self, n=-1):
-                """Simulates the read method in a file stream.
-
-                :Parameters:
-                    - `n`: int
-
-                :Returns:
-                    str
-
-                """
-                if self._chunks:
-                    return self._chunks.pop(0)
-                else:
-                    return ''
-
-            def __len__(self):
-                """To make len(ReadableStream) work.
-                """
-                return sum([len(chunk) for chunk in self._chunks])
-
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         
@@ -3634,35 +3586,35 @@ class CRUDTests(unittest.TestCase):
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id ends with a space.', e.message)
+            self.assertEqual('Id ends with a space.', str(e))
         # Id shouldn't contain '/'.
         database_definition = { 'id': 'id_with_illegal/_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
         # Id shouldn't contain '\\'.
         database_definition = { 'id': 'id_with_illegal\\_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
         # Id shouldn't contain '?'.
         database_definition = { 'id': 'id_with_illegal?_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
         # Id shouldn't contain '#'.
         database_definition = { 'id': 'id_with_illegal#_char' }
         try:
             client.CreateDatabase(database_definition)
             self.assertFalse(True)
         except ValueError as e:
-            self.assertEqual('Id contains illegal chars.', e.message)
+            self.assertEqual('Id contains illegal chars.', str(e))
 
         # Id can begin with space
         database_definition = { 'id': ' id_begin_space' }

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -3776,6 +3776,10 @@ class CRUDTests(unittest.TestCase):
             return conflict['_self']
 
 if __name__ == '__main__':
+    if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
+        raise Exception(
+            "You must specify your Azure DocumentDB account values for "
+            "'masterKey' and 'host' at the top of this file to run the tests.")
     try:
         unittest.main()
     except SystemExit as inst:

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -23,8 +23,8 @@ import pydocumentdb.base as base
 from struct import *
 from __builtin__ import *
 
-masterKey = '[YOUR_KEY_HERE]'
-host = '[YOUR_ENDPOINT_HERE]'
+TEST_DB_NAME = 'sample database'
+
 
 if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
     raise Exception(
@@ -79,7 +79,7 @@ class CRUDTests(unittest.TestCase):
         databases = list(client.ReadDatabases())
         # create a database.
         before_create_databases_count = len(databases)
-        database_definition = { 'id': 'sample database' }
+        database_definition = { 'id': TEST_DB_NAME }
         created_db = client.CreateDatabase(database_definition)
         self.assertEqual(created_db['id'], database_definition['id'])
         # Read databases after creation.
@@ -141,7 +141,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         collections = list(client.ReadCollections(self.GetDatabaseLink(created_db, is_name_based)))
         # create a collection
         before_create_collections_count = len(collections)
@@ -305,7 +305,7 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_partition_key_extraction_special_chars(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         collection_definition1 = {   'id': 'sample collection1', 
                                     'partitionKey': 
@@ -373,7 +373,7 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_document_crud_and_query(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {   'id': 'sample collection', 
                                     'partitionKey': 
@@ -494,7 +494,7 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_permissions(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         collection_definition = {   'id': 'sample collection', 
                                     'partitionKey': 
@@ -596,7 +596,7 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_execute_stored_procedure(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         collection_definition = {   'id': 'sample collection', 
                                     'partitionKey': 
@@ -675,7 +675,7 @@ class CRUDTests(unittest.TestCase):
 
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {   'id': 'sample collection', 
                                     'partitionKey': 
@@ -870,7 +870,7 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_partition_key_value_types(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {   'id': 'sample collection1', 
                                     'partitionKey': 
@@ -941,7 +941,7 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_conflit_crud_and_query(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         collection_definition = {   'id': 'sample collection', 
                                     'partitionKey': 
@@ -1034,7 +1034,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         created_collection = client.CreateCollection(
             self.GetDatabaseLink(created_db, is_name_based),
@@ -1135,7 +1135,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create test database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # Create bunch of collections participating in partitioning
         collection0 = client.CreateCollection(
@@ -1270,7 +1270,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create test database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # Create bunch of collections participating in partitioning
         collection0 = client.CreateCollection(
@@ -1355,7 +1355,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(0, len(queryIterable.fetch_next_block()))
         
     def test_hash_partition_resolver(self):
-        created_db = { 'id': 'sample database' }
+        created_db = { 'id': TEST_DB_NAME }
         
         # Create bunch of collections participating in partitioning
         collection0 = { 'id': 'coll_0' }
@@ -1493,7 +1493,7 @@ class CRUDTests(unittest.TestCase):
 
     def test_range_partition_resolver(self):
         # create test database
-        created_db = { 'id': 'sample database' }
+        created_db = { 'id': TEST_DB_NAME }
         
         # Create bunch of collections participating in partitioning
         collection0 = { 'id': 'coll_0' }
@@ -1567,7 +1567,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
 
         # create database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         # create collection
         created_collection = client.CreateCollection(
@@ -1673,7 +1673,7 @@ class CRUDTests(unittest.TestCase):
         
     def _test_spatial_index(self, is_name_based):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # partial policy specified
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based),
@@ -1762,7 +1762,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based),
@@ -1927,7 +1927,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
         
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # create collection
         collection = client.CreateCollection(
@@ -2062,7 +2062,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # list users
         users = list(client.ReadUsers(self.GetDatabaseLink(db, is_name_based)))
         before_create_count = len(users)
@@ -2117,7 +2117,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
         
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # read users and check count
         users = list(client.ReadUsers(self.GetDatabaseLink(db, is_name_based)))
@@ -2177,7 +2177,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create user
         user = client.CreateUser(self.GetDatabaseLink(db, is_name_based), { 'id': 'new user' })
         # list permissions
@@ -2241,7 +2241,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
         
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # create user
         user = client.CreateUser(self.GetDatabaseLink(db, is_name_based), { 'id': 'new user' })
@@ -2330,7 +2330,7 @@ class CRUDTests(unittest.TestCase):
 
             """
             # create database
-            db = client.CreateDatabase({ 'id': 'sample database' })
+            db = client.CreateDatabase({ 'id': TEST_DB_NAME })
             # create collection1
             collection1 = client.CreateCollection(
                 db['_self'], { 'id': 'sample collection' })
@@ -2470,7 +2470,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based),
@@ -2550,7 +2550,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
         
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # create collection
         collection = client.CreateCollection(
@@ -2640,7 +2640,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based),
@@ -2709,7 +2709,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
         
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # create collection
         collection = client.CreateCollection(
@@ -2796,7 +2796,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based),
@@ -2872,7 +2872,7 @@ class CRUDTests(unittest.TestCase):
                                                 {'masterKey': masterKey})
         
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         # create collection
         collection = client.CreateCollection(
@@ -2962,7 +2962,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based),
@@ -3038,7 +3038,7 @@ class CRUDTests(unittest.TestCase):
     def _test_create_default_indexing_policy(self, is_name_based):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         # no indexing policy specified
         collection = client.CreateCollection(self.GetDatabaseLink(db, is_name_based), {'id': 'TestCreateDefaultPolicy01'})
@@ -3152,7 +3152,7 @@ class CRUDTests(unittest.TestCase):
                 dict
 
             """
-            db = client.CreateDatabase({ 'id': 'sample database' })
+            db = client.CreateDatabase({ 'id': TEST_DB_NAME })
             collection = client.CreateCollection(
                 db['_self'],
                 { 'id': 'sample collection' })
@@ -3317,7 +3317,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collections
         collection1 = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based), { 'id': 'sample collection 1' })
@@ -3382,7 +3382,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 { 'masterKey': masterKey })
         # create database
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # create collection
         collection = client.CreateCollection(
             self.GetDatabaseLink(db, is_name_based), { 'id': 'sample collection' })
@@ -3445,7 +3445,7 @@ class CRUDTests(unittest.TestCase):
     def test_offer_read_and_query(self):
         client = document_client.DocumentClient(host, { 'masterKey': masterKey })
         # Create database.
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # Create collection.
         collection = client.CreateCollection(db['_self'], { 'id': 'sample collection' })
         offers = list(client.ReadOffers())
@@ -3490,7 +3490,7 @@ class CRUDTests(unittest.TestCase):
     def test_offer_replace(self):
         client = document_client.DocumentClient(host, { 'masterKey': masterKey })
         # Create database.
-        db = client.CreateDatabase({ 'id': 'sample database' })
+        db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         # Create collection.
         collection = client.CreateCollection(db['_self'], { 'id': 'sample collection' })
         offers = list(client.ReadOffers())
@@ -3528,7 +3528,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host,
                                                 {'masterKey': masterKey})
         # create database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         collections = list(client.ReadCollections(created_db['_self']))
         # create a collection
         before_create_collections_count = len(collections)
@@ -3577,7 +3577,7 @@ class CRUDTests(unittest.TestCase):
         
     def _test_index_progress_headers(self, is_name_based):
         client = document_client.DocumentClient(host, { 'masterKey': masterKey })
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         consistent_coll = client.CreateCollection(self.GetDatabaseLink(created_db, is_name_based), { 'id': 'consistent_coll' })
         client.ReadCollection(self.GetDocumentCollectionLink(created_db, consistent_coll, is_name_based))
         self.assertFalse(http_constants.HttpHeaders.LazyIndexingProgress in client.last_response_headers)
@@ -3670,7 +3670,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
         # create database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         # pascalCase
         collection_definition1 = { 'id': 'sampleCollection' }
@@ -3702,7 +3702,7 @@ class CRUDTests(unittest.TestCase):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
         # create database
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
 
         # unicode chars in Hindi for Id which translates to: "Hindi is the national language of India"
         collection_definition1 = { 'id': u'हिन्दी भारत की राष्ट्रीय भाषा है' }

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -64,7 +64,8 @@ class CRUDTests(unittest.TestCase):
         if not databases:
             return
         for database in databases:
-            client.DeleteDatabase(self.GetDatabaseLink(database, False))
+            if database['id'] == TEST_DB_NAME:
+                client.DeleteDatabase(self.GetDatabaseLink(database, False))
 
     def test_database_crud_self_link(self):
         self._test_database_crud(False)

--- a/test/crud_tests.py
+++ b/test/crud_tests.py
@@ -26,7 +26,13 @@ from __builtin__ import *
 masterKey = '[YOUR_KEY_HERE]'
 host = '[YOUR_ENDPOINT_HERE]'
 
-#IMPORTANT NOTES: 
+if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
+    raise Exception(
+        "You must specify your Azure DocumentDB account values for "
+        "'masterKey' and 'host' at the top of this file to run the tests.")
+
+
+#IMPORTANT NOTES:
   
 #  	Most test cases in this file create collections in your DocumentDB account.
 #  	Collections are billing entities.  By running these test cases, you may incur monetary costs on your account.
@@ -3776,10 +3782,6 @@ class CRUDTests(unittest.TestCase):
             return conflict['_self']
 
 if __name__ == '__main__':
-    if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
-        raise Exception(
-            "You must specify your Azure DocumentDB account values for "
-            "'masterKey' and 'host' at the top of this file to run the tests.")
     try:
         unittest.main()
     except SystemExit as inst:

--- a/test/ttl_tests.py
+++ b/test/ttl_tests.py
@@ -9,7 +9,12 @@ import pydocumentdb.errors as errors
 masterKey = '[YOUR_KEY_HERE]'
 host = '[YOUR_ENDPOINT_HERE]'
 
-#IMPORTANT NOTES: 
+if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
+    raise Exception(
+        "You must specify your Azure DocumentDB account values for "
+        "'masterKey' and 'host' at the top of this file to run the tests.")
+
+#IMPORTANT NOTES:
   
 #  	Most test cases in this file create collections in your DocumentDB account.
 #  	Collections are billing entities.  By running these test cases, you may incur monetary costs on your account.

--- a/test/ttl_tests.py
+++ b/test/ttl_tests.py
@@ -8,6 +8,7 @@ import pydocumentdb.errors as errors
 
 masterKey = '[YOUR_KEY_HERE]'
 host = '[YOUR_ENDPOINT_HERE]'
+TEST_DB_NAME = 'sample database'
 
 if masterKey == '[YOUR_KEY_HERE]' or host == '[YOUR_ENDPOINT_HERE]':
     raise Exception(
@@ -44,12 +45,13 @@ class TTLTests(unittest.TestCase):
 
         databases = list(client.ReadDatabases())
         for database in databases:
-            client.DeleteDatabase(database['_self'])
+            if database['id'] == TEST_DB_NAME:
+                client.DeleteDatabase(database['_self'])
 
     def test_collection_and_document_ttl_values(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {'id' : 'sample collection1',
                                  'defaultTtl' : 5
@@ -123,7 +125,7 @@ class TTLTests(unittest.TestCase):
     def test_document_ttl_with_positive_defaultTtl(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {'id' : 'sample collection',
                                  'defaultTtl' : 5
@@ -205,7 +207,7 @@ class TTLTests(unittest.TestCase):
     def test_document_ttl_with_negative_one_defaultTtl(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {'id' : 'sample collection',
                                  'defaultTtl' : -1
@@ -252,7 +254,7 @@ class TTLTests(unittest.TestCase):
     def test_document_ttl_with_no_defaultTtl(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {'id' : 'sample collection' }
         
@@ -279,7 +281,7 @@ class TTLTests(unittest.TestCase):
     def test_document_ttl_misc(self):
         client = document_client.DocumentClient(host, {'masterKey': masterKey})
 
-        created_db = client.CreateDatabase({ 'id': 'sample database' })
+        created_db = client.CreateDatabase({ 'id': TEST_DB_NAME })
         
         collection_definition = {'id' : 'sample collection',
                                  'defaultTtl' : 8


### PR DESCRIPTION
* updated README.md to highlight the need for your account keys & that running tests costs money, 
* updated tests to _only_ delete the test database
* tests throw exception if you haven't entered your account key and endpoint. This should make it more obvious when tests fail, previously tests would fail with an encoding error if the key/endpoint had not been entered.