### PR TITLE
Avoid mutating the root logger

### DIFF
--- a/pydocumentdb/endpoint_discovery_retry_policy.py
+++ b/pydocumentdb/endpoint_discovery_retry_policy.py
@@ -24,6 +24,9 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
+
+
 class _EndpointDiscoveryRetryPolicy(object):
     """The endpoint discovery retry policy class used for geo-replicated database accounts
        to handle the write forbidden exceptions due to writable/readable location changes
@@ -40,7 +43,7 @@ class _EndpointDiscoveryRetryPolicy(object):
         self._max_retry_attempt_count = _EndpointDiscoveryRetryPolicy.Max_retry_attempt_count
         self.current_retry_attempt_count = 0
         self.retry_after_in_milliseconds = _EndpointDiscoveryRetryPolicy.Retry_after_in_milliseconds
-        logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+        logger.setLevel(logging.INFO)
 
     def ShouldRetry(self, exception):
         """Returns true if should retry based on the passed-in exception.
@@ -53,7 +56,7 @@ class _EndpointDiscoveryRetryPolicy(object):
         """
         if self.current_retry_attempt_count < self._max_retry_attempt_count and self.global_endpoint_manager.EnableEndpointDiscovery:
             self.current_retry_attempt_count += 1
-            logging.info('Write location was changed, refreshing the locations list from database account and will retry the request.')
+            logger.info('Write location was changed, refreshing the locations list from database account and will retry the request.')
 
             # Refresh the endpoint list to refresh the new writable and readable locations
             self.global_endpoint_manager.RefreshEndpointList()


### PR DESCRIPTION
Using `logging.basicConfig(level=logging.INFO)` mutates the root logger for the current Python interpreter. This means that any library which imports the pydocumentdb library will have its log level set to `INFO` which leads to unexpected behavior.

Some libraries even have tests to defend against this behavior, e.g. Celery: https://github.com/celery/celery/blob/120770929f/t/unit/conftest.py#L231-L244

To fix this unexpected behavior, this commit introduces a new logger that's specific to the endpoint discovery retry policy and only mutates the log level of that specific logger.