### PR TITLE
Fix Bug#131: 0 rows returns when server return 429 on first page of results.

### DIFF
--- a/pydocumentdb/execution_context/base_execution_context.py
+++ b/pydocumentdb/execution_context/base_execution_context.py
@@ -124,13 +124,7 @@ class _QueryExecutionContextBase(object):
             if fetched_items:
                 break
         return fetched_items   
-            
-    def _fetch_items_helper_with_retries(self, fetch_function):
-        def callback():
-            return self._fetch_items_helper_no_retries(fetch_function)
-                
-        return retry_utility._Execute(self._client, self._client._global_endpoint_manager, callback)
-    
+
 
 class _DefaultQueryExecutionContext(_QueryExecutionContextBase):
     """
@@ -155,7 +149,7 @@ class _DefaultQueryExecutionContext(_QueryExecutionContextBase):
     
     def _fetch_next_block(self):
         while super(self.__class__, self)._has_more_pages() and len(self._buffer) == 0:
-            return self._fetch_items_helper_with_retries(self._fetch_function)
+            return self._fetch_items_helper_no_retries(self._fetch_function)
         
 class _MultiCollectionQueryExecutionContext(_QueryExecutionContextBase):
     """
@@ -224,7 +218,7 @@ class _MultiCollectionQueryExecutionContext(_QueryExecutionContextBase):
         :rtype: list
         """
         # Fetch next block of results by executing the query against the current document collection
-        fetched_items = self._fetch_items_helper_with_retries(self._fetch_function)
+        fetched_items = self._fetch_items_helper_no_retries(self._fetch_function)
 
         # If there are multiple document collections to query for(in case of partitioning), keep looping through each one of them,
         # creating separate feed queries for each collection and fetching the items
@@ -244,7 +238,7 @@ class _MultiCollectionQueryExecutionContext(_QueryExecutionContextBase):
 
                 self._fetch_function = fetch_fn
 
-                fetched_items = self._fetch_items_helper_with_retries(self._fetch_function)
+                fetched_items = self._fetch_items_helper_no_retries(self._fetch_function)
                 self._current_collection_index += 1
             else:
                 break

--- a/pydocumentdb/retry_options.py
+++ b/pydocumentdb/retry_options.py
@@ -32,7 +32,7 @@ class RetryOptions(object):
     :ivar int MaxWaitTimeInSeconds:
         Max wait time in seconds to wait for a request while the retries are happening. Default value 30 seconds.
     """
-    def __init__(self, max_retry_attempt_count = 9, fixed_retry_interval_in_milliseconds = None, max_wait_time_in_seconds = 30):
+    def __init__(self, max_retry_attempt_count = 17, fixed_retry_interval_in_milliseconds = None, max_wait_time_in_seconds = 60):
         self._max_retry_attempt_count = max_retry_attempt_count
         self._fixed_retry_interval_in_milliseconds = fixed_retry_interval_in_milliseconds
         self._max_wait_time_in_seconds = max_wait_time_in_seconds

--- a/test/retry_policy_tests.py
+++ b/test/retry_policy_tests.py
@@ -221,7 +221,7 @@ class Test_retry_policy_tests(unittest.TestCase):
         result_docs = list(docs)
         self.assertEqual(result_docs[0]['id'], 'doc1')
         self.assertEqual(result_docs[1]['id'], 'doc2')
-        self.assertEqual(self.counter, 12)
+        self.assertEqual(self.counter, 6)
 
         self.counter = 0;
         retry_utility._ExecuteFunction = self.OriginalExecuteFunction
@@ -300,7 +300,7 @@ class Test_retry_policy_tests(unittest.TestCase):
             self.assertEqual(ex.status_code, StatusCodes.TOO_MANY_REQUESTS)
 
         client._DocumentClient__Post = original_post_function
-        client.DeleteDocument(created_doc['_self'])
+        client.DeleteDocument(created_document['_self'])
 
     def _MockPost429(self, url, path, body, headers):
         raise errors.HTTPFailure(StatusCodes.TOO_MANY_REQUESTS,

--- a/test/retry_policy_tests.py
+++ b/test/retry_policy_tests.py
@@ -1,4 +1,4 @@
-﻿#The MIT License (MIT)
+#The MIT License (MIT)
 #Copyright (c) 2014 Microsoft Corporation
 
 #Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -274,6 +274,38 @@ class Test_retry_policy_tests(unittest.TestCase):
         self.assertEqual(self.counter, 7)
 
         retry_utility._ExecuteFunction = self.OriginalExecuteFunction
+
+    def test_429_on_first_page(self):
+        client = document_client.DocumentClient(Test_retry_policy_tests.host, {'masterKey': Test_retry_policy_tests.masterKey})
+
+        document_definition = { 'id': 'doc429',
+                                'name': 'sample document',
+                                'key': 'value'}
+
+        created_document = client.CreateDocument(self.created_collection['_self'], document_definition)
+
+        # Mock an overloaded server which always returns 429 Too Many
+        # Requests, by hooking the client's POST method.
+        original_post_function = client._DocumentClient__Post
+        client._DocumentClient__Post = self._MockPost429
+
+        # Test: query for the document.  Expect the mock overloaded server
+        # to raise a 429 exception.
+        try:
+            query = client.QueryDocuments(self.created_collection['_self'], "SELECT * FROM c")
+            docs = list(query) # force execution now
+            self.assertFalse(True, 'function should raise HTTPFailure.')
+
+        except errors.HTTPFailure as ex:
+            self.assertEqual(ex.status_code, StatusCodes.TOO_MANY_REQUESTS)
+
+        client._DocumentClient__Post = original_post_function
+        client.DeleteDocument(created_doc['_self'])
+
+    def _MockPost429(self, url, path, body, headers):
+        raise errors.HTTPFailure(StatusCodes.TOO_MANY_REQUESTS,
+                                 "Request rate is too large",
+                                 {HttpHeaders.RetryAfterInMilliseconds: 500})
 
     def _MockExecuteFunction(self, function, *args, **kwargs):
         raise errors.HTTPFailure(StatusCodes.TOO_MANY_REQUESTS, "Request rate is too large", {HttpHeaders.RetryAfterInMilliseconds: self.retry_after_in_milliseconds})


### PR DESCRIPTION
For background, read #131

This happens because `base_execution_context._fetch_items_helper_with_retries()` runs the requests wrapped in a `retry_utility._Execute()` call, which does retries.  However, much lower down the call stack more retries will be done because `synchronized_request.SynchronizedRequest()` also uses `retry_utility.Execute()` to do retries.

These two nested retry policies cause the following problem:  When the innermost policy decides there have been too many failures it re-raises the `HTTPFailure` exception (`retry_utility.py:84`)  However, the outermost retry policy catches that (`base_execution_context.py:132`), and attempts another round of innermost retries.  The first of these sees misleading request processing state: it has received 0 rows of results, and does not have a continuation token:
```
base_execution_context.py:116
fetched_items = []
while self._continuation or not self._has_started
    do the work
return fetched_items
```
In this case, `self._continuation` is `None` because this is the first page of the query and the server has not returned a continuation token.  And `self._has_started` is `True` because of the first round of retries.  So the while loop never executes, and it returns the empty array of `fetched_items`.

So the client (incorrectly) decides the query is complete and returns 0 rows. Bug.

This pull request:

- adds a new test which repros this bug.
- fixes the bug, by removing the outermost layer of retries.
- increases the default level of retries, now that two retry policies are no longer nested.
- fixes a test which was counting the number of requests issued, not that the two policies are no longer nested.

It is safe to remove the outermost layer of retries, because the library code seems to have evolved as follows.  Initially, only the outermost layer of retries existed.  Then support for queries failing over to another geo-location was added, by putting retries down at the bottom level (in `synchronized_request`, see [Commit 9d1bac3](https://github.com/Azure/azure-documentdb-python/commit/9d1bac3ab9c7b6b2a7015994bf57ed7d80426220).)  But at this time, the uppermost layer of retries was not removed.  So now the code does nested retries.  Only the innermost layer is actually needed.

Also, notice that nested retries is another bug.  It means that when user code specifies retry options, they apply to both inner and outer retry policies, and get compounded together.  We have tests which cover this (`test/retry_policy_tests.py`), but they mock out the retry utility's `_Execute` function, so by-pass the nesting, which makes the tests pass despite the fact that when it runs for real it won't do what the user expect.  Eg, a retry limit of 8 calls will turn into 8*8 = 64!

Users may have inadvertently been relying on this very large level of retries, which is why the default retry level has been increased.  Not to 64, but double (8 to 16).

**Testing**: all existing tests pass, and the newly added test passes with the fix, and fails without the fix.  Additionally, we've been running this against a live CosmosDB server and it's working nicely for us.